### PR TITLE
Allow the introduction to be optional

### DIFF
--- a/js/config/form.js
+++ b/js/config/form.js
@@ -11,7 +11,7 @@ const formConfig = {
   trackingPrefix: 'form-',
   transformForSubmit: '',
   submitUrl: '',
-  //introduction: Introduction,
+  introduction: Introduction,
   confirmation: '',
   defaultDefinitions: {
     fullName

--- a/js/config/form.js
+++ b/js/config/form.js
@@ -11,7 +11,7 @@ const formConfig = {
   trackingPrefix: 'form-',
   transformForSubmit: '',
   submitUrl: '',
-  introduction: Introduction,
+  //introduction: Introduction,
   confirmation: '',
   defaultDefinitions: {
     fullName

--- a/js/routes.jsx
+++ b/js/routes.jsx
@@ -8,7 +8,9 @@ const routes = createRoutes(formConfig);
 const route = {
   path: '/',
   component: Form,
-  indexRoute: { onEnter: (nextState, replace) => replace(routes[0].path) },
+  indexRoute: {
+    onEnter: (nextState, replace) => replace(formConfig.urlPrefix+routes[0].path)
+  },
   childRoutes: routes,
 };
 

--- a/js/routes.jsx
+++ b/js/routes.jsx
@@ -3,11 +3,13 @@ import { createRoutes } from 'us-forms-system/lib/js/helpers';
 import formConfig from './config/form';
 import Form from './components/Form.jsx';
 
+const routes = createRoutes(formConfig);
+
 const route = {
   path: '/',
   component: Form,
-  indexRoute: { onEnter: (nextState, replace) => replace('/introduction') },
-  childRoutes: createRoutes(formConfig),
+  indexRoute: { onEnter: (nextState, replace) => replace(routes[0].path) },
+  childRoutes: routes,
 };
 
 export default route;


### PR DESCRIPTION
Since us-forms-system creates a full routes list including the intro, review, and confirmation pages (if present), we can just set the initial route to the first page on the routes list.

I wanted to write a unit test for this but it's in the starter app and there's no current testing in this repo so it's a rather heavy lift at the moment. I'm not sure whether it makes sense to create tests here since most other cases involving the form pages themselves should be covered by the tests in us-forms-system.