### PR TITLE
Upgrade url-parse to fix security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8920,9 +8920,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
-      "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "dev": true,
       "requires": {
         "querystringify": "^2.0.0",


### PR DESCRIPTION
There was a [security vulnerability](https://www.npmjs.com/advisories/678) with the package url-parse, which is a dependency of a couple of our dependencies. Upgrade this package to fix the vulnerability.