### PR TITLE
Fix errors in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7335,7 +7335,6 @@
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
       "integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
-      "dev": true,
       "requires": {
         "create-react-class": "^15.6.0",
         "fbjs": "^0.8.9",
@@ -7348,7 +7347,6 @@
       "version": "15.6.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
       "integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
-      "dev": true,
       "requires": {
         "fbjs": "^0.8.9",
         "loose-envify": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "us-forms-system-starter-app",
   "version": "1.0.0",
   "description": "Test US Forms System",
-  "main": "index.js",
+  "main": "app.js",
   "directories": {},
   "scripts": {
     "start": "webpack-dev-server --open --config webpack.dev.js",
@@ -22,8 +22,6 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "css-loader": "^0.28.11",
-    "react": "^15.6.2",
-    "react-dom": "^15.6.2",
     "style-loader": "^0.21.0",
     "svg-url-loader": "^2.3.2",
     "url-loader": "^1.0.1",
@@ -35,6 +33,8 @@
     "webpack-merge": "^4.1.3"
   },
   "dependencies": {
+    "react": "^15.6.2",
+    "react-dom": "^15.6.2",
     "us-forms-system": "^1.1.0"
   }
 }


### PR DESCRIPTION
I noticed this when trying to import the project into a codesandbox.io page and it failed.

* React is a direct `dependency` and not a `devDependency`. We got away with this because the project happened to find the copy already installed by USFS.

* The `main` entry should point to `app.js` since `index.js` does not exist. This is used by codesandbox.io but not by webpack's dev or production builds which [have their own reference to `app.js`](https://github.com/usds/us-forms-system-starter-app/blob/1a90a336efddda5f4eca6a82040bdf0c392b2790/webpack.common.js#L11).