### PR TITLE
Add redux-thunk

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, useRouterHistory } from 'react-router';
 import { Provider } from 'react-redux';
-import { createStore, combineReducers } from 'redux';
+import { createStore, combineReducers, applyMiddleware } from 'redux';
+import thunk from 'redux-thunk';
 import { createHistory } from 'history';
 
 import 'us-forms-system/lib/css/styles.css';
@@ -10,7 +11,10 @@ import 'us-forms-system/lib/css/styles.css';
 import route from './js/routes.jsx';
 import reducer from './js/reducers';
 
-const store = createStore(combineReducers(reducer));
+const store = createStore(
+  combineReducers(reducer),
+  applyMiddleware(thunk)
+);
 
 const browserHistory = useRouterHistory(createHistory)({
   basename: ''

--- a/package-lock.json
+++ b/package-lock.json
@@ -8876,6 +8876,11 @@
         "symbol-observable": "^1.0.3"
       }
     },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "prop-types": "^15.6.2",
     "react": "^15.6.2",
     "react-dom": "^15.6.2",
+    "redux-thunk": "^2.3.0",
     "us-forms-system": "^1.1.0",
     "uswds": "^1.6.3"
   }


### PR DESCRIPTION
Was receiving the following error due to submitForm action being a thunk.

createStore.js?61ed:152 
Uncaught Error: Actions must be plain objects. Use custom middleware for async actions.
    at dispatch (createStore.js?61ed:152)
    at Object.eval [as submitForm] (bindActionCreators.js?f901:3)
    at SubmitController._this.handleSubmit (SubmitController.js?03af:121)
    at HTMLUnknownElement.boundFunc (ReactErrorUtils.js?0d18:63)
    at Object.ReactErrorUtils.invokeGuardedCallback (ReactErrorUtils.js?0d18:69)
    at executeDispatch (EventPluginUtils.js?a975:83)
    at Object.executeDispatchesInOrder (EventPluginUtils.js?a975:106)
    at executeDispatchesAndRelease (EventPluginHub.js?4a97:41)
    at executeDispatchesAndReleaseTopLevel (EventPluginHub.js?4a97:52)
    at Array.forEach (<anonymous>)