### PR TITLE
Responsive rendering fix

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>Test U.S. Forms System</title>
   </head>
   <body>


### PR DESCRIPTION
By default, the starter app renders in mobile incorrectly:
<img width="456" alt="screen shot 2018-12-18 at 5 43 35 am" src="https://user-images.githubusercontent.com/6384156/50151971-fec9f680-0287-11e9-908c-d2111038a6d5.png">

Adding this meta to the head fixes the issue:
<img width="497" alt="screen shot 2018-12-18 at 5 43 04 am" src="https://user-images.githubusercontent.com/6384156/50152008-10130300-0288-11e9-85bb-f1fe06220301.png">
